### PR TITLE
Support more character types in instance folder name

### DIFF
--- a/src/classes/WorkspaceManager.ts
+++ b/src/classes/WorkspaceManager.ts
@@ -353,7 +353,7 @@ export class WorkspaceManager{
                 replaceWithPath = "\\\\";
             }
 
-            let regexPreparedPath = wsFolder.uri.fsPath.replace(new RegExp("\\" + path.sep, 'g'), replaceWithPath) + replaceWithPath + "(\\w*)" + replaceWithPath + "(\\w*)"; 
+            let regexPreparedPath = wsFolder.uri.fsPath.replace(new RegExp("\\" + path.sep, 'g'), replaceWithPath) + replaceWithPath + "(.*?)" + replaceWithPath + "(\\w*)"; 
             this.logger.debug(this.lib, func, 'RegexPreparedPath', regexPreparedPath);
             
             let InstanceAppComponents = new RegExp(regexPreparedPath);


### PR DESCRIPTION
I noticed with a custom url instance the folder name would not work if it's something like (subdomain.domain.topleveldomain), so this is a regex update for that.