### PR TITLE
Setup new OAUTH now defaults Global App scope and Removed Legacy

### DIFF
--- a/ext_version.json
+++ b/ext_version.json
@@ -1,1 +1,1 @@
-{"last_installed":"1.36.2"}
+{"last_installed":"1.37.1"}

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
     "displayName": "S.N.I.C.H. Canary",
     "description": "ServiceNow Integrated Code Helper - Canary. Get the latest as I build stuff ready to be tested! Provide feedback to integratenate@gmail.com",
     "icon": "images/icon-canary.png",
-    "version": "1.37.0",
+    "version": "1.37.1",
     "liveVersion": "1.1.0",
-    "canaryVersion": "1.37.0",
+    "canaryVersion": "1.37.1",
     "betaVersion": "1.0.6",
     "keywords": [
         "SNICH",

--- a/src/classes/InstanceConfigManager.ts
+++ b/src/classes/InstanceConfigManager.ts
@@ -173,8 +173,8 @@ export class InstancesList {
         let authOptions = <Array<SNQPItem>>[
             { label: "Basic", description: "Use basic authentication. Password stored un-encrypted.", value: "basic" },
             { label: "OAuth (Preferred)", description: "Use OAuth to authenticate. SNICH never sees your username or password.", value: "oauth-authorization_code" },
-            { label: "OAuth (Legacy)", description: "Use OAuth to authenticate. SNICH sees your PW but we do not store.", value: "oauth" },
         ];
+        //{ label: "OAuth (Legacy)", description: "Use OAuth to authenticate. SNICH sees your PW but we do not store.", value: "oauth" },
 
         let authSelection = await vscode.window.showQuickPick(authOptions, <vscode.QuickPickOptions>{ placeHolder: "Select an authentcation option", ignoreFocusOut: true });
 
@@ -532,7 +532,7 @@ export class InstanceMaster {
         }
 
         if (launchToOAuthAppRegistry.label == 'Create New') {
-            let newAppQueryParams = 'sys_id=-1&sysparm_query=type=client^redirect_url=https://localhost:62000/snich_oauth_redirect^name=VSCode%20S.N.I.C.H.%20Users^logo_url=https://github.com/RaynorUE/snich/blob/master/images/icon-sn-oauth.PNG%3Fraw=true'; //?raw=true'
+            let newAppQueryParams = 'sys_id=-1&sysparm_query=type=client^redirect_url=https://localhost:62000/snich_oauth_redirect^name=VSCode%20S.N.I.C.H.%20Users^logo_url=https://github.com/RaynorUE/snich/blob/master/images/icon-sn-oauth.PNG%3Fraw=true&sysparm_transaction_scope=global'; //?raw=true'
             let appRegURL = vscode.Uri.parse(`${this.getURL()}/oauth_entity.do?${newAppQueryParams}`, true);
             vscode.env.openExternal(appRegURL)
         }


### PR DESCRIPTION
When setting up "New OAUTH" app registry, we send along sysparm_transaction_scope=global  helping to reduce accidental inclusion in a scoped application. 

Also removed the "Legacy" OAuth option.