### PR TITLE
Fixing on load acvitation failure

### DIFF
--- a/ext_version.json
+++ b/ext_version.json
@@ -1,1 +1,1 @@
-{"last_installed":"1.39.1"}
+{"last_installed":"1.40.4"}

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
     "displayName": "S.N.I.C.H. Canary",
     "description": "ServiceNow Integrated Code Helper - Canary. Get the latest as I build stuff ready to be tested! Provide feedback to integratenate@gmail.com",
     "icon": "images/icon-canary.png",
-    "version": "1.40.0",
+    "version": "1.40.4",
     "liveVersion": "1.1.0",
-    "canaryVersion": "1.40.0",
+    "canaryVersion": "1.40.4",
     "betaVersion": "1.0.6",
     "keywords": [
         "SNICH",
@@ -52,7 +52,7 @@
         "onCommand:snich.instance.setup.new_table",
         "onCommand:snich.application.load.all",
         "onCommand:snich.activeEditor.compare_with_server",
-        "workspaceContains:./**/.vscode/snich_config.json"
+        "workspaceContains:*/.vscode/snich_config.json"
     ],
     "main": "./dist/extension.js",
     "contributes": {


### PR DESCRIPTION
When loading up the extension activation checking your workspace to contain a SNICHconfig was faililng. This fixes that!